### PR TITLE
Fix LinkedIn API issue on login #65

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -19,7 +19,6 @@ function uwp_get_social_profile( $provider, $provider_uid )
     global $wpdb;
 
     $sql = "SELECT user_id FROM `{$wpdb->base_prefix}uwp_social_profiles` WHERE provider = %s AND identifier = %s";
-
     return $wpdb->get_var( $wpdb->prepare( $sql, $provider, $provider_uid ) );
 }
 
@@ -34,9 +33,9 @@ function uwp_get_social_profile_by_email_verified( $email_verified )
 
 function uwp_social_store_user_profile( $user_id, $provider, $profile )
 {
-    
+
     global $wpdb;
-    
+
     $wpdb->show_errors();
 
     $sql = "SELECT id, object_sha FROM `{$wpdb->base_prefix}uwp_social_profiles` where user_id = %d and provider = %s and identifier = %s";
@@ -88,7 +87,7 @@ function uwp_social_store_user_profile( $user_id, $provider, $profile )
         'city',
         'zip'
     );
-    
+
     foreach( $profile as $key => $value )
     {
         $key = strtolower($key);
@@ -162,7 +161,7 @@ function uwp_social_build_provider_config( $provider )
 
     if( $provider_key == "linkedin" )
     {
-        $config["providers"][$provider]["scope"] = "r_liteprofile r_emailaddress";
+        $config["providers"][$provider]["scope"] = "profile email openid w_member_social";
     }
 
     // set custom config for google

--- a/includes/social.php
+++ b/includes/social.php
@@ -247,7 +247,8 @@ function uwp_social_get_user_data( $provider, $redirect_to ) {
 	$adapter = uwp_social_get_provider_adapter( $provider );
 
 	$hybridauth_user_email          = isset( $hybridauth_user_profile->email ) ? sanitize_email( $hybridauth_user_profile->email ) : '';
-	$hybridauth_user_email_verified = isset( $hybridauth_user_profile->emailVerified ) ? sanitize_email( $hybridauth_user_profile->emailVerified ) : $hybridauth_user_email;
+	$hybridauth_user_email_verified = isset( $hybridauth_user_profile->emailVerified ) ? boolval( $hybridauth_user_profile->emailVerified ) : $hybridauth_user_email;
+
 
 	// check if user already exist in uwp social profiles
 	if ( ! empty( $hybridauth_user_profile->identifier ) ) {
@@ -259,9 +260,9 @@ function uwp_social_get_user_data( $provider, $redirect_to ) {
 	// if not found in uwp social profiles, then check his verified email
 	if ( ! $user_id && ! empty( $hybridauth_user_email_verified ) ) {
 		// check if the verified email exist in wp_users
-		$user_id = (int) uwp_email_exists( $hybridauth_user_email_verified );
+		$user_id = (int) uwp_email_exists( $hybridauth_user_email );
 
-		// the user exists in Wordpress
+		// the user exists in WordPress
 		$wordpress_user_id = $user_id;
 
 		// check if the verified email exist in uwp social profiles
@@ -478,7 +479,8 @@ function uwp_request_user_social_profile( $provider ) {
 		$adapter = uwp_social_get_provider_adapter( $provider );
 
 		$config = uwp_get_provider_config_from_session_storage( $provider );
-		// if user authenticated successfully with social network
+
+        // if user authenticated successfully with social network
 		if ( $adapter->isConnected() ) {
 			// grab user profile via hybridauth api
 			$hybridauth_user_profile = $adapter->getUserProfile();


### PR DESCRIPTION

The old scopes do not work. I verified in my LinkedIn app. There's no way to edit the scopes except for adding from the products.
https://community.auth0.com/t/linkedin-integration-scopes-dont-match/114676

The scope provided for the app depends upon the products the created app has access to. See here: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin%2Fcontext&tabs=HTTPS1 So the scopes need to be enabled from the **Products** tab. In our case, it's `profile, email, openid and w_member_social` which can be enabled by requesting access to **Share on LinkedIn** and **Sign In with LinkedIn using OpenID Connect** products.

